### PR TITLE
Modularización ruta eventType y corrección de errores de sintaxis

### DIFF
--- a/api/src/controllers/getDetailById.js
+++ b/api/src/controllers/getDetailById.js
@@ -15,7 +15,7 @@ if (!event || event.length === 0) {
     throw new Error("This event does not excist");
 }
 
-  const infoEevnt = event.map(event => {
+  const infoEvent = event.map(event => {
     return {
      id: event.id,
      title: event.title,
@@ -27,7 +27,7 @@ if (!event || event.length === 0) {
     }
   })
 
-  return  infoEevnt[0]
+  return  infoEvent[0]
 
 };
 

--- a/api/src/controllers/getEventTypes.js
+++ b/api/src/controllers/getEventTypes.js
@@ -1,18 +1,9 @@
-const axios = require("axios");
 const { EventTypes } = require("../db");
 
-const URL = "http://localhost:5000/EventTypes/";
-
 const getEventTypes = async () => {
-  const check = EventTypes.findAll();
-  if (check != []) {
-    return check;
-  } else {
-    const apiEventTypes = (await axios.get(URL)).data;
-    await EventTypes.bulkCreate(apiEventTypes);
-    const check = EventTypes.findAll();
-    return check;
-  }
+  const allEventTypes = EventTypes.findAll();
+  //const eventTypesNames = allEventTypes.map((eventType) => eventType.name);
+  return allEventTypes;
 };
 
 module.exports = { getEventTypes };

--- a/api/src/controllers/getEvents.js
+++ b/api/src/controllers/getEvents.js
@@ -13,7 +13,6 @@ const getEvents = async () => {
       return { ...rest };
     });
 
-    // console.log(apiEventsNew);
     await Events.bulkCreate(apiEventsNew);
   }
   return check;
@@ -29,7 +28,3 @@ const getEventsByName = async (name) => {
 };
 
 module.exports = { getEvents, getEventsByName };
-
-
-
-module.exports = { getEvents, getEventsByName};

--- a/api/src/handlers/getEventTypesHandler.js
+++ b/api/src/handlers/getEventTypesHandler.js
@@ -3,7 +3,7 @@ const { getEventTypes } = require("../controllers/getEventTypes");
 const getEventTypesHandler = async (req, res) => {
   try {
     const data = await getEventTypes();
-    res.status(201).json(data);
+    res.status(200).json(data);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/api/src/routes/eventRouter.js
+++ b/api/src/routes/eventRouter.js
@@ -4,12 +4,10 @@ const { getDetailByIdHandler } = require("../handlers/getDetailByIdHandler");
 const { createTicketHandler } = require("../handlers/createTicketHandler");
 const { createEventHandler } = require("../handlers/createEventHandler");
 const { validateEvent } = require("../utiles/validate");
-const { getEventTypesHandler } = require("../handlers/getEventTypesHandler");
 
 const eventRouter = Router();
 
 eventRouter.get("/", getEventsHandler);
-eventRouter.get("/eventtype", getEventTypesHandler);
 eventRouter.post("/ticket", createTicketHandler);
 eventRouter.post("/", validateEvent, createEventHandler);
 eventRouter.get("/:id", getDetailByIdHandler);

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -1,8 +1,10 @@
 const { Router } = require("express");
 const eventRouter = require("./eventRouter");
+const eventTypeRouter = require("./eventTypesRouter");
 
 const router = Router();
 
 router.use("/events", eventRouter);
+router.use("/eventTypes", eventTypeRouter);
 
 module.exports = router;


### PR DESCRIPTION
Modularizacion de la ruta eventType y corrección de un error de sintaxis en una variable del getEventDetail que decía infoEvnets en vez de infoEvents. 
En el getEvents también había 2 module.exports, borramo 1